### PR TITLE
feat: add splash screen, center-centric layout, and disable text selection for console-like feel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,18 +1,40 @@
+/* --- GLOBAL RESET & CENTER CENTRIC --- */
 html,
 body {
   overflow-x: hidden;
   height: 100%;
+  width: 100%;
 }
 
 body {
   margin: 0;
-  padding: 20px 0;
+  padding: 0;
   font-family: 'Press Start 2P', cursive;
   background-color: #212529;
   background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
   background-size: 20px 20px;
   color: #fff;
+
+  /* CENTER CENTRIC MAGIC */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+/* NO SELECT EXPERIENCE (APP FEEL) */
+* {
+  user-select: none;
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+/Edge */
+}
+
+/* Allow text selection only in logs if user really wants to copy */
+.logs-terminal p {
+  user-select: text;
 }
 
 [v-cloak] {
@@ -25,12 +47,47 @@ body {
   margin: 0 auto;
   position: relative;
   transition: transform 0.1s;
+  /* Ensure container doesn't overflow vertically on small screens */
+  padding: 20px 0;
 }
 
+/* SPLASH SCREEN STYLES */
+.splash-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  z-index: 10000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.splash-logo {
+  font-size: 40px;
+  color: #fff;
+  text-shadow: 4px 4px 0 #209cee;
+  text-align: center;
+  margin-bottom: 20px;
+  letter-spacing: 5px;
+}
+
+.fade-slow-enter-active,
+.fade-slow-leave-active {
+  transition: opacity 1.5s;
+}
+.fade-slow-enter,
+.fade-slow-leave-to {
+  opacity: 0;
+}
+
+/* Existing Animations */
 .shake-screen {
   animation: shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }
-
 .main-title {
   color: #f7d51d;
   text-align: center;
@@ -38,7 +95,6 @@ body {
   text-shadow: 4px 4px 0px #000;
   font-size: 28px;
 }
-
 .text-center {
   text-align: center;
 }
@@ -53,7 +109,6 @@ body {
 .fade-leave-to {
   opacity: 0;
 }
-
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -65,7 +120,7 @@ body {
   }
 }
 
-/* === UI ELEMENTS === */
+/* UI ELEMENTS */
 .key-hint {
   font-size: 8px;
   background: rgba(255, 255, 255, 0.2);
@@ -76,7 +131,6 @@ body {
   vertical-align: middle;
   border: 1px solid rgba(255, 255, 255, 0.3);
 }
-
 .btn-subtext {
   font-size: 8px;
   opacity: 0.8;
@@ -85,14 +139,13 @@ body {
   text-transform: none;
 }
 
-/* === CHARACTER GRID === */
+/* GRID */
 .character-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   gap: 15px;
   margin: 20px 0;
 }
-
 .char-card {
   background: #fff;
   border: 4px solid #ccc;
@@ -102,38 +155,32 @@ body {
   transition: all 0.1s;
   color: #000;
 }
-
 .char-card:hover {
   transform: translateY(-5px);
   border-color: #209cee;
 }
-
 .char-card.focused {
   border-color: #209cee;
   transform: scale(1.1);
   box-shadow: 0 0 15px #209cee;
   z-index: 10;
 }
-
 .char-card.selected {
   border-color: #f7d51d;
   background-color: #fffde7;
   transform: scale(1.05);
   box-shadow: 0 0 10px #f7d51d;
 }
-
 .char-card.is-secret {
   background: #000;
   color: #f7d51d;
   border-color: #f7d51d;
   animation: glow 1.5s infinite alternate;
 }
-
 .secret-text {
   color: #f7d51d;
   text-shadow: 1px 1px 0 #000;
 }
-
 @keyframes glow {
   from {
     box-shadow: 0 0 5px #f7d51d;
@@ -142,7 +189,6 @@ body {
     box-shadow: 0 0 20px #f7d51d;
   }
 }
-
 .char-card img {
   width: 100%;
   height: auto;
@@ -150,13 +196,12 @@ body {
   display: block;
   margin-bottom: 5px;
 }
-
 .char-name {
   font-size: 8px;
   margin: 0;
 }
 
-/* === BATTLE STYLES === */
+/* BATTLE */
 .players {
   display: flex;
   justify-content: space-between;
@@ -164,7 +209,6 @@ body {
   margin-bottom: 30px;
   gap: 10px;
 }
-
 .player-card {
   background: #fff;
   color: #212529;
@@ -175,12 +219,10 @@ body {
   box-shadow: 0 4px 0 rgba(0, 0, 0, 0.5);
   transition: transform 0.2s;
 }
-
 .player-card.active-turn {
   border: 4px solid #f7d51d;
   transform: translateY(-4px);
 }
-
 .player__media {
   position: relative;
   width: 100%;
@@ -190,7 +232,6 @@ body {
   justify-content: center;
   align-items: center;
 }
-
 .player__avatar {
   width: 100px;
   height: 100px;
@@ -199,12 +240,10 @@ body {
   border: 4px solid #212529;
   background: #eee;
 }
-
 .player__avatar.is-dead {
   filter: grayscale(100%) contrast(1.2);
   opacity: 0.6;
 }
-
 .vs-badge {
   background: #e76e55;
   color: #fff;
@@ -216,7 +255,6 @@ body {
   z-index: 5;
   transform: rotate(-10deg);
 }
-
 .identity-badge {
   position: absolute;
   top: -10px;
@@ -224,7 +262,6 @@ body {
   transform: translateX(-50%);
   z-index: 10;
 }
-
 .player__name {
   margin-top: 0;
   margin-bottom: 8px;
@@ -235,21 +272,19 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
 .hp-text {
   text-align: center;
   font-size: 10px;
   margin-bottom: 4px;
   font-weight: bold;
 }
-
 .nes-progress {
   height: 20px;
   border-radius: 0;
   box-shadow: inset 2px 2px 0 rgba(0, 0, 0, 0.2);
 }
 
-/* === CONTROLS === */
+/* CONTROLS */
 .control-panel {
   background: #fff;
   color: #000;
@@ -257,21 +292,18 @@ body {
   margin-bottom: 20px;
   text-align: center;
 }
-
 .actions {
   display: flex;
   flex-direction: column;
   gap: 16px;
   align-items: center;
 }
-
 .combat-buttons {
   display: flex;
   gap: 16px;
   flex-wrap: wrap;
   justify-content: center;
 }
-
 .actions__btn {
   width: 150px;
   font-size: 12px;
@@ -282,7 +314,6 @@ body {
   padding: 10px;
   transition: all 0.1s;
 }
-
 .actions__btn.focused,
 .nes-btn.focused {
   border: 4px solid #f7d51d;
@@ -291,18 +322,16 @@ body {
   position: relative;
   z-index: 10;
 }
-
 .is-disabled {
   opacity: 0.5;
   filter: grayscale(100%);
   pointer-events: none;
 }
 
-/* === LOGS === */
+/* LOGS */
 .logs-container {
   margin-bottom: 40px;
 }
-
 .logs-terminal {
   background-color: #000 !important;
   color: #33ff00;
@@ -314,7 +343,6 @@ body {
   line-height: 1.8;
   box-shadow: 8px 8px 0 rgba(0, 0, 0, 0.5);
 }
-
 .logs-terminal::-webkit-scrollbar {
   width: 10px;
 }
@@ -325,7 +353,7 @@ body {
   background: #33ff00;
 }
 
-/* === CHEAT NOTIFICATION === */
+/* FX */
 .cheat-toast {
   position: fixed;
   top: 20px;
@@ -340,8 +368,6 @@ body {
   font-size: 12px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
 }
-
-/* === ANIMATIONS & FX === */
 .visual-fx-container {
   position: absolute;
   top: 0;
@@ -364,7 +390,6 @@ body {
     opacity: 1;
   }
 }
-
 .shake {
   animation: shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }
@@ -387,7 +412,6 @@ body {
     transform: translate3d(4px, 0, 0);
   }
 }
-
 .hit-flash {
   filter: sepia(100%) saturate(300%) hue-rotate(-50deg) brightness(1.5);
   transition: filter 0.1s;
@@ -432,7 +456,6 @@ body {
   opacity: 0;
   transform: translate(-50%, -50px);
 }
-
 #confetti-container {
   position: fixed;
   top: 0;
@@ -476,6 +499,9 @@ body {
   }
   .character-grid {
     grid-template-columns: repeat(3, 1fr);
+  }
+  .splash-logo {
+    font-size: 24px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -3,19 +3,28 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Retro Battle: Final Version</title>
+    <title>Retro Battle: Console Edition</title>
     <link rel="stylesheet" href="./css/nes.css" />
     <link rel="stylesheet" href="./css/style.css" />
   </head>
   <body>
     <div id="app" v-cloak>
+      <transition name="fade-slow">
+        <div v-if="showSplash" class="splash-screen">
+          <div class="splash-content">
+            <h1 class="splash-logo">VUE.JS<br />SYSTEMS</h1>
+            <p class="blink-anim">INITIALIZING...</p>
+          </div>
+        </div>
+      </transition>
+
       <div id="confetti-container"></div>
 
       <transition name="fade">
         <div v-if="cheatActivated" class="cheat-toast">🔓 GOD MODE ACTIVATED!</div>
       </transition>
 
-      <div class="container" :class="{ 'shake-screen': globalShake }">
+      <div class="container" :class="{ 'shake-screen': globalShake }" v-show="!showSplash">
         <h1 class="main-title">RETRO BATTLE</h1>
 
         <div v-if="isTitleScreen" class="screen-title text-center fade-in">
@@ -31,7 +40,7 @@
               PRESS START <span class="key-hint">[ENTER]</span>
             </button>
           </div>
-          <div style="margin-top: 20px; opacity: 0.6; font-size: 10px">v5.1 Stable Build</div>
+          <div style="margin-top: 20px; opacity: 0.6; font-size: 10px">v6.0 Console Edition</div>
         </div>
 
         <div v-if="status.selecting" class="screen-select fade-in">
@@ -221,7 +230,7 @@
               <p class="title">Battle Log</p>
               <div class="logs-terminal">
                 <p v-for="(log, index) in logs" :key="index" v-html="`> ` + log"></p>
-                <p v-if="logs.length === 0">Waiting for command... [ARROWS] to Select, [ENTER] to Execute.</p>
+                <p v-if="logs.length === 0">Waiting for command...</p>
               </div>
             </div>
           </div>

--- a/js/script.js
+++ b/js/script.js
@@ -20,6 +20,9 @@ const app = new Vue({
       selectedPlayer: { player1: {}, player2: {} },
       health: { player1: 100, player2: 100 },
       activeFx: { player1: [], player2: [] },
+
+      // State Management
+      showSplash: true, // NEW: Start with Splash
       status: {
         selecting: false,
         loading: false,
@@ -27,11 +30,10 @@ const app = new Vue({
         winner: false,
         giveUp: false,
       },
+
       tempSelection: null,
       focusedCharIndex: 0,
       battleMenuIndex: 0,
-      battleMenuIndex: 0,
-
       turnInProgress: false,
       globalShake: false,
       loadingProgress: 0,
@@ -61,36 +63,39 @@ const app = new Vue({
 
   computed: {
     isTitleScreen() {
-      return !this.status.selecting && !this.status.loading && !this.status.play && !this.status.winner;
+      // Hanya tampilkan title jika splash sudah selesai
+      return (
+        !this.showSplash && !this.status.selecting && !this.status.loading && !this.status.play && !this.status.winner
+      );
     },
   },
 
   mounted() {
     window.addEventListener('keydown', this.handleKeydown);
+
+    // SPLASH SCREEN TIMER
+    setTimeout(() => {
+      this.showSplash = false;
+    }, 2500); // 2.5 Detik durasi splash
   },
+
   beforeDestroy() {
     window.removeEventListener('keydown', this.handleKeydown);
   },
 
   methods: {
-    // --- KEYBOARD LOGIC ---
+    // === KEYBOARD CONTROLLER ===
     handleKeydown(e) {
-      if (this.isTitleScreen) {
-        this.inputBuffer.push(e.key);
-        if (this.inputBuffer.length > 20) this.inputBuffer.shift(); // Memory fix
+      if (this.showSplash || this.status.loading) return;
 
-        // Simple array check for Konami Code
+      if (this.isTitleScreen) {
+        // Konami Code Check
+        this.inputBuffer.push(e.key);
+        if (this.inputBuffer.length > 20) this.inputBuffer.shift();
         const bufferString = this.inputBuffer.slice(-this.konamiCode.length).join(',');
         const codeString = this.konamiCode.join(',');
+        if (bufferString === codeString) this.activateCheat();
 
-        if (bufferString === codeString) {
-          this.activateCheat();
-        }
-      }
-
-      if (this.status.loading) return;
-
-      if (this.isTitleScreen) {
         if (e.key === 'Enter') this.goToSelectScreen();
         return;
       }
@@ -100,7 +105,6 @@ const app = new Vue({
         if (e.key === 'ArrowLeft') this.moveGridFocus(-1, 0);
         if (e.key === 'ArrowDown') this.moveGridFocus(0, 1);
         if (e.key === 'ArrowUp') this.moveGridFocus(0, -1);
-
         if (e.key === 'Enter') this.confirmSelection();
         if (e.key === 'Escape') this.backToTitle();
         return;
@@ -194,7 +198,6 @@ const app = new Vue({
       if (this.battleMenuIndex === 2) this.playerHeal();
     },
 
-    // --- NAVIGATION ---
     goToSelectScreen() {
       this.status.selecting = true;
       this.status.play = false;
@@ -314,7 +317,6 @@ const app = new Vue({
       const logsContainer = document.querySelector('.logs-terminal');
       this.logs.push(message);
       if (logsContainer) {
-        // Fix: Use nextTick for reliable scrolling
         this.$nextTick(() => {
           logsContainer.scrollTo({ left: 0, top: logsContainer.scrollHeight, behavior: 'smooth' });
         });
@@ -365,7 +367,6 @@ const app = new Vue({
       container.innerHTML = '';
     },
 
-    // --- ACTIONS ---
     playerAttack(type) {
       if (this.turnInProgress) return;
       this.turnInProgress = true;
@@ -396,7 +397,6 @@ const app = new Vue({
         this.createLog(`💨 Attack MISSED on ${p2Name}!`);
       } else {
         this.health.player2 -= damage;
-        // Fix: Prevent Negative HP
         if (this.health.player2 < 0) this.health.player2 = 0;
 
         this.triggerVisualEffect('player2');
@@ -474,7 +474,6 @@ const app = new Vue({
           this.createLog(`💨 ${p2Name} tried a Special Attack but MISSED!`);
         } else {
           this.health.player1 -= damage;
-          // Fix: Prevent Negative HP
           if (this.health.player1 < 0) this.health.player1 = 0;
 
           this.triggerVisualEffect('player1');
@@ -520,7 +519,6 @@ const app = new Vue({
       this.hideDialogGiveUp();
     },
 
-    // --- FIX: FUNCTION RESTORED INSIDE METHODS ---
     healthBarColorStatus(value) {
       return {
         'is-primary': value > 50,


### PR DESCRIPTION
- Introduce retro "Booting" splash screen on initial load
- Redesign layout with full-height flexbox for perfect centering on mobile and desktop
- Disable text/image selection globally via CSS to prevent highlighting
- Ensure consistent focused experience across all screen sizes